### PR TITLE
Fix alpine builds

### DIFF
--- a/php7.2/alpine/intl-mcrypt-memcached-mongodb-redis/Dockerfile
+++ b/php7.2/alpine/intl-mcrypt-memcached-mongodb-redis/Dockerfile
@@ -1,12 +1,12 @@
-FROM php:7.2.9-alpine@sha256:b7470c2adc0163b91a27d0fd1e107b5fb57bacc28c682acd2514e8289e8fa50b
+FROM php:7.2.9-alpine3.7@sha256:2a5e38c14e669a1d2274bf1cba46c2926800e08c4bae34e4b1fa301f1bd449fd
 
 RUN apk add --no-cache zlib-dev=1.2.11-r1 \
     libmcrypt-dev=2.5.8-r7 \
-    icu-libs=60.2-r2 \
-    curl-dev=7.61.1-r2 \
+    icu-dev=59.1-r1 \
+    curl-dev=7.61.1-r3 \
     libmemcached-dev=1.0.18-r2 \
-    gnupg=2.2.8-r0 \
-    fontconfig=2.12.6-r1 \
+    gnupg=2.2.3-r1 \
+    fontconfig=2.12.6-r0 \
     autoconf=2.69-r2 \
     $PHPIZE_DEPS
 

--- a/php7.2/alpine/mcrypt-memcached-mongodb-redis/Dockerfile
+++ b/php7.2/alpine/mcrypt-memcached-mongodb-redis/Dockerfile
@@ -1,11 +1,11 @@
-FROM php:7.2.9-alpine@sha256:b7470c2adc0163b91a27d0fd1e107b5fb57bacc28c682acd2514e8289e8fa50b
+FROM php:7.2.9-alpine3.7@sha256:2a5e38c14e669a1d2274bf1cba46c2926800e08c4bae34e4b1fa301f1bd449fd
 
 RUN apk add --no-cache zlib-dev=1.2.11-r1 \
     libmcrypt-dev=2.5.8-r7 \
-    curl-dev=7.61.1-r2 \
+    curl-dev=7.61.1-r3 \
     libmemcached-dev=1.0.18-r2 \
-    gnupg=2.2.8-r0 \
-    fontconfig=2.12.6-r1 \
+    gnupg=2.2.3-r1 \
+    fontconfig=2.12.6-r0 \
     autoconf=2.69-r2 \
     $PHPIZE_DEPS
 


### PR DESCRIPTION
The alpine build fail because mongodb-1.4.4 is not compatible with libressl 2.7.
Libressl 2.6 is only available for alpine 3.7 and we were at 3.8.